### PR TITLE
simplify collision detection

### DIFF
--- a/src/Level.cpp
+++ b/src/Level.cpp
@@ -107,17 +107,18 @@ bool Level::rotate()
 
 bool Level::move(int cxDistance, int cyDistance)
 {
-    if (posX + cxDistance < 0 || posY + cyDistance < 0 ||
-        posX + current->getWidth() + cxDistance > width)
-        return false;
-    if (cxDistance < 0 && isHitLeft())
-        return false;
-    if (cxDistance > 0 && isHitRight())
-        return false;
-    if (cyDistance < 0 && isHitBottom())
+    int newX = posX + cxDistance;
+    int newY = posY + cyDistance;
+    if (newX < 0 || newY < 0 ||
+        newX + current->getWidth() > width)
         return false;
     clear(*current);
-    return place(posX + cxDistance, posY + cyDistance, *current);
+    if (!isCovered(*current, newX, newY)) {
+        place(newX, newY, *current);
+        return true;
+    }
+    place(posX, posY, *current);
+    return false;
 }
 
 void Level::clear(const Piece &piece)
@@ -139,55 +140,6 @@ void Level::dropRandomPiece()
     current = next;
     next = pieceSet.getRandomPiece();
     place(3, height - 1, *current);
-}
-
-bool Level::isHitBottom() const
-{
-    POINT apt[4];
-    int n = current->getSkirt(apt);
-    int x, y;
-    for (int i = 0; i < n; i++)
-    {
-        x = posX + apt[i].x;
-        y = posY + apt[i].y;
-        if (y < height && (y == 0 || board[x][y-1] != RGB(0,0,0)))
-            return true;
-    }
-    return false;
-}
-
-bool Level::isHitLeft() const
-{
-    POINT apt[4];
-    int n = current->getLeftSide(apt);
-    int x, y;
-    for (int i = 0; i < n; i++)
-    {
-        x = posX + apt[i].x;
-        y = posY + apt[i].y;
-        if (y > height - 1)
-            continue;
-        if (x == 0 || board[x-1][y] != RGB(0,0,0))
-            return true;
-    }
-    return false;
-}
-
-bool Level::isHitRight() const
-{
-    POINT apt[4];
-    int n = current->getRightSide(apt);
-    int x, y;
-    for (int i = 0; i < n; i++)
-    {
-        x = posX + apt[i].x;
-        y = posY + apt[i].y;
-        if (y > height - 1)
-            continue;
-        if (x == width - 1 || board[x+1][y] != RGB(0,0,0))
-            return true;
-    }
-    return false;
 }
 
 bool Level::isCovered(const Piece &piece, int x, int y) const

--- a/src/Level.h
+++ b/src/Level.h
@@ -52,11 +52,6 @@ protected:
     // Releases the next dropping piece
     void dropRandomPiece();
 
-    // Checks if the piece hits the boundary
-    bool isHitBottom() const;
-    bool isHitLeft() const;
-    bool isHitRight() const;
-
     // Checks if a piece can move to a position
     bool isCovered(const Piece &piece, int x, int y) const;
 

--- a/src/Piece.cpp
+++ b/src/Piece.cpp
@@ -40,63 +40,6 @@ void Piece::getBody(POINT *apt) const
         apt[i] = body[i];
 }
 
-int Piece::getSkirt(POINT *apt) const
-{
-    int i = 0;
-    for (int x = 0; x < width; x++)
-    {
-        for (int y = 0; y < height; y++)
-        {
-            if (isPointExists(x, y))
-            {
-                apt[i].x = x;
-                apt[i].y = y;
-                i++;
-                break;
-            }
-        }
-    }
-    return i;
-}
-
-int Piece::getLeftSide(POINT *apt) const
-{
-    int i = 0;
-    for (int y = 0; y < height; y++)
-    {
-        for (int x = 0; x < height; x++)
-        {
-            if (isPointExists(x, y))
-            {
-                apt[i].x = x;
-                apt[i].y = y;
-                i++;
-                break;
-            }
-        }
-    }
-    return i;
-}
-
-int Piece::getRightSide(POINT *apt) const
-{
-    int i = 0;
-    for (int y = 0; y < height; y++)
-    {
-        for (int x = width - 1; x >= 0; x--)
-        {
-            if (isPointExists(x, y))
-            {
-                apt[i].x = x;
-                apt[i].y = y;
-                i++;
-                break;
-            }
-        }
-    }
-    return i;
-}
-
 void Piece::print() const
 {
     cout << "width = " << width << endl;

--- a/src/Piece.h
+++ b/src/Piece.h
@@ -43,11 +43,6 @@ public:
     // Gets the points of the piece
     void getBody(POINT *apt) const;
 
-    // Gets the bottom, left, or right part of points of the piece
-    int getSkirt(POINT *apt) const;
-    int getLeftSide(POINT *apt) const;
-    int getRightSide(POINT *apt) const;
-
     // Determines if the piece has a point (x, y)
     bool isPointExists(int x, int y) const;
 


### PR DESCRIPTION
I think I found a way to remove a good chunk of collision detection code.  Instead of using logic to figure out which blocks are apart of the current piece and which are apart of the placed pieces, I modified the code to remove the current piece before checking for collisions on it's new position.  Now we can simply use `isCovered` to check whether the new position has a collision.

I'm not 100% sure this has the same behavior as before, but I tested playing a game and it seems to work.